### PR TITLE
Decoding fails for keyed structs in a `singleValueContainer`

### DIFF
--- a/Sources/BinaryCodable/Decoding/DecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/DecodingNode.swift
@@ -8,6 +8,13 @@ final class DecodingNode: AbstractDecodingNode, Decoder {
     
     private let isInUnkeyedContainer: Bool
 
+    init(storage: Storage, isOptional: Bool = false, path: [CodingKey], info: UserInfo, isInUnkeyedContainer: Bool = false) {
+        self.storage = storage
+        self.isOptional = isOptional
+        self.isInUnkeyedContainer = isInUnkeyedContainer
+        super.init(path: path, info: info)
+    }
+
     init(data: Data, isOptional: Bool = false, path: [CodingKey], info: UserInfo) {
         self.storage = .data(data)
         self.isOptional = isOptional
@@ -33,7 +40,7 @@ final class DecodingNode: AbstractDecodingNode, Decoder {
 
     func singleValueContainer() throws -> SingleValueDecodingContainer {
         return ValueDecoder(
-            data: storage.useAsDecoder(),
+            storage: storage,
             isOptional: isOptional, 
             isInUnkeyedContainer: isInUnkeyedContainer,
             path: codingPath,

--- a/Sources/BinaryCodable/Decoding/ValueDecoder.swift
+++ b/Sources/BinaryCodable/Decoding/ValueDecoder.swift
@@ -2,22 +2,28 @@ import Foundation
 
 final class ValueDecoder: AbstractDecodingNode, SingleValueDecodingContainer {
 
-    let data: BinaryStreamProvider
+    private var storage: Storage
 
     private let isOptional: Bool
     
     private let isInUnkeyedContainer: Bool
 
-    init(data: BinaryStreamProvider, isOptional: Bool, isInUnkeyedContainer: Bool, path: [CodingKey], info: UserInfo) {
-        self.data = data
+    init(storage: Storage, isOptional: Bool, isInUnkeyedContainer: Bool, path: [CodingKey], info: UserInfo) {
+        self.storage = storage
         self.isOptional = isOptional
         self.isInUnkeyedContainer = isInUnkeyedContainer
         super.init(path: path, info: info)
     }
 
+    private func asDecoder() -> BinaryStreamProvider {
+        let decoder = self.storage.useAsDecoder()
+        self.storage = .decoder(decoder)
+        return decoder
+    }
+
     func decodeNil() -> Bool {
         do {
-            let byte = try data.getByte(path: codingPath)
+            let byte = try asDecoder().getByte(path: codingPath)
             return byte == 0
         } catch {
             return false
@@ -26,18 +32,28 @@ final class ValueDecoder: AbstractDecodingNode, SingleValueDecodingContainer {
 
     func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
         if type is AnyOptional.Type {
-            let node = DecodingNode(decoder: data, isOptional: true, path: codingPath, info: userInfo)
+            let node = DecodingNode(storage: storage, isOptional: true, path: codingPath, info: userInfo)
             return try T.init(from: node)
         } else if let Primitive = type as? DecodablePrimitive.Type {
             let data: Data
-            if !isInUnkeyedContainer, Primitive.dataType == .variableLength, !isOptional, let d = self.data as? DataDecoder {
-                data = d.getAllData()
+            if !isInUnkeyedContainer, Primitive.dataType == .variableLength, !isOptional {
+                switch storage {
+                case .data(let d):
+                    data = d
+                case .decoder(let decoder):
+                    if let d = decoder as? DataDecoder {
+                        data = d.getAllData()
+                    } else {
+                        data = try decoder.getData(for: Primitive.dataType, path: codingPath)
+                    }
+                }
             } else {
-                data = try self.data.getData(for: Primitive.dataType, path: codingPath)
+                let decoder = asDecoder()
+                data = try decoder.getData(for: Primitive.dataType, path: codingPath)
             }
             return try Primitive.init(decodeFrom: data, path: codingPath) as! T
         } else {
-            let node = DecodingNode(decoder: data, path: codingPath, info: userInfo)
+            let node = DecodingNode(storage: storage, path: codingPath, info: userInfo)
             return try T.init(from: node)
         }
     }

--- a/Tests/BinaryCodableTests/CustomDecodingTests.swift
+++ b/Tests/BinaryCodableTests/CustomDecodingTests.swift
@@ -133,7 +133,7 @@ final class CustomDecodingTests: XCTestCase {
     
     func testEncodingAsDifferentType() throws {
         let version = Version(major: 1, minor: 2, patch: 3)
-        let time = Date.now
+        let time = Date()
         let sValue = Timestamped(value: version.rawValue, timestamp: time)
         let vValue = Timestamped(value: version, timestamp: time)
         let encoder = BinaryEncoder()


### PR DESCRIPTION
This is for now mostly a bug report, adding a failing test reproducing the issue at hand, as I don't have a solution to this without better understanding the expected behavior.

## 🐛 Problem

Assume I have the following structs:
```
struct Wrapper: Codable, Equatable {
    let wrapped: Wrapped

    init(wrapped: Wrapped) {
        self.wrapped = wrapped
    }

    init(from decoder: Decoder) throws {
        let container = try decoder.singleValueContainer()
        self.wrapped = try container.decode(Wrapped.self)
    }

    func encode(to encoder: Encoder) throws {
        var container = encoder.singleValueContainer()
        try container.encode(wrapped)
    }
}
struct Wrapped: Codable, Equatable {
    let val: String
}
```

I presume the values of both structs are expected to encode and decode the same binary format, as the type `Wrapper` acts a transparent wrapper from an encoding/decoding perspective. That at least is the current behavior, encoding-wise. So while they encode indeed to the same data, the decoding of `Wrapper` however does always (!) fail.

```
failed: caught error: "dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "Premature end of data", underlyingError: nil))
```

In a more complex situation, I also saw this failing with:
```
failed: caught error: "dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "Unknown data type 4", underlyingError: nil))
```

## 🔍 Solution Explored

To me, the problem seemed to be that `DecodingNode.singleValueContainer()` turns its `storage` into an indexed `BinaryStreamProvider`, which will be eventually turned back into `Data`. While converting back and forth here seemed innocuous at first glance, I presumed they inadvertently consume the count byte(s) in this case. However when I attempted to fix this myself (by making `ValueDecoder` operate directly on the `Storage` instead), I found out that while this does indeed fix the new test, it does break several other tests which seem to rely on exactly this behavior of `singleValueContainer`. (`testDecodingAsDifferentType`, `testStringEnumEncoding`, `testStringEncoding`, `UUIDEncodingTests`)

## 🛟 Help Required

I'm not quite sure on the design of the binary format and whether this is supposed to work as is or the wrapped struct should be rather prepended by a count byte.