### PR TITLE
Provide `codingPath` when decoding fails due to corrupt data

### DIFF
--- a/Sources/BinaryCodable/Common/AnyCodingKey.swift
+++ b/Sources/BinaryCodable/Common/AnyCodingKey.swift
@@ -1,0 +1,35 @@
+
+/// Helpful for appending mixed coding keys.
+struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = "\(intValue)"
+    }
+
+    init(stringValue: String) {
+        self.intValue = nil
+        self.stringValue = stringValue
+    }
+}
+
+extension AnyCodingKey {
+    init<T: CodingKey>(_ key: T) {
+        self.stringValue = key.stringValue
+        self.intValue = key.intValue
+    }
+}
+
+extension AnyCodingKey: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) {
+        self.init(stringValue: value)
+    }
+}
+
+extension AnyCodingKey: ExpressibleByIntegerLiteral {
+    init(integerLiteral value: Int) {
+        self.init(intValue: value)
+    }
+}

--- a/Sources/BinaryCodable/Decoding/KeyedDecoder.swift
+++ b/Sources/BinaryCodable/Decoding/KeyedDecoder.swift
@@ -10,12 +10,33 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
         while decoder.hasMoreBytes {
             let (key, dataType) = try DecodingKey.decode(from: decoder, path: path)
 
-            let data = try decoder.getData(for: dataType, path: path)
-
-            guard content[key] != nil else {
-                content[key] = [data]
-                continue
+            do {
+                let data = try decoder.getData(for: dataType, path: path)
+                guard content[key] != nil else {
+                    content[key] = [data]
+                    continue
+                }
+            } catch DecodingError.dataCorrupted(let context) {
+                let codingKey = {
+                    switch key {
+                    case .stringKey(let stringValue):
+                        return Key(stringValue: stringValue)
+                    case .intKey(let intValue):
+                        return Key(intValue: intValue)
+                    }
+                }()
+                var newCodingPath = path
+                if let codingKey {
+                    newCodingPath += [codingKey]
+                }
+                let newContext = DecodingError.Context(
+                    codingPath: newCodingPath,
+                    debugDescription: context.debugDescription,
+                    underlyingError: context.underlyingError
+                )
+                throw DecodingError.dataCorrupted(newContext)
             }
+
             throw DecodingError.multipleValuesForKey(path, key)
         }
         self.content = content.mapValues { parts in
@@ -60,27 +81,33 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
     }
 
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
-        let data = try getData(forKey: key)
-        if type is AnyOptional.Type {
-            let node = DecodingNode(data: data, isOptional: true, path: codingPath, info: userInfo)
-            return try T.init(from: node)
-        } else if let Primitive = type as? DecodablePrimitive.Type {
-            return try Primitive.init(decodeFrom: data, path: codingPath + [key]) as! T
-        } else {
-            let node = DecodingNode(data: data, path: codingPath, info: userInfo)
-            return try T.init(from: node)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            if type is AnyOptional.Type {
+                let node = DecodingNode(data: data, isOptional: true, path: codingPath, info: userInfo)
+                return try T.init(from: node)
+            } else if let Primitive = type as? DecodablePrimitive.Type {
+                return try Primitive.init(decodeFrom: data, path: codingPath + [key]) as! T
+            } else {
+                let node = DecodingNode(data: data, path: codingPath, info: userInfo)
+                return try T.init(from: node)
+            }
         }
     }
 
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        let data = try getData(forKey: key)
-        let container = try KeyedDecoder<NestedKey>(data: data, path: codingPath, info: userInfo)
-        return KeyedDecodingContainer(container)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            let container = try KeyedDecoder<NestedKey>(data: data, path: codingPath, info: userInfo)
+            return KeyedDecodingContainer(container)
+        }
     }
 
     func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        let data = try getData(forKey: key)
-        return try UnkeyedDecoder(data: data, path: codingPath, info: userInfo)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            return try UnkeyedDecoder(data: data, path: codingPath, info: userInfo)
+        }
     }
 
     func superDecoder() throws -> Decoder {
@@ -91,5 +118,18 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
     func superDecoder(forKey key: Key) throws -> Decoder {
         let data = try getData(forKey: key)
         return DecodingNode(data: data, path: codingPath, info: userInfo)
+    }
+
+    private func wrapError<T>(forKey key: Key, _ block: () throws -> T) throws -> T {
+        do {
+            return try block()
+        } catch DecodingError.dataCorrupted(let context) {
+            let newContext = DecodingError.Context(
+                codingPath: codingPath + [key] + context.codingPath,
+                debugDescription: context.debugDescription,
+                underlyingError: context.underlyingError
+            )
+            throw DecodingError.dataCorrupted(newContext)
+        }
     }
 }

--- a/Tests/BinaryCodableTests/CodingPathTests.swift
+++ b/Tests/BinaryCodableTests/CodingPathTests.swift
@@ -1,0 +1,339 @@
+import XCTest
+import BinaryCodable
+
+final class CodingPathTests: XCTestCase {
+
+    struct KeyedBox<T: Codable>: Codable {
+        enum CodingKeys: String, CodingKey {
+            case val
+        }
+
+        let val: T
+
+        init(_ val: T) {
+            self.val = val
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.val = try container.decode(T.self, forKey: .val)
+        }
+    }
+
+    struct CorruptBool: Codable, Equatable, ExpressibleByBooleanLiteral {
+        let val: Bool
+
+        init(booleanLiteral value: BooleanLiteralType) {
+            self.val = value
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.val = try container.decode(Bool.self)
+            if val == false {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Found false!")
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(val)
+        }
+    }
+
+    func testStructWithCorruptArrayElement() throws {
+        struct Test: Codable, Equatable {
+            let arr: [CorruptBool]
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1, 0 // True, true, corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "arr", "2"])
+        }
+    }
+
+    func testStructWithArrayMissingLastElement() throws {
+        struct Test: Codable, Equatable {
+            let arr: [Bool]
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1 // Only two elements provided!
+        ]
+
+        var data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: Data(corruptedBytes))
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testStructWithArrayMissingLastElementButCorrectLength() throws {
+        struct Test: Codable, Equatable {
+            let arr: [Bool]
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1 // Only two elements provided!
+        ]
+
+        var data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        data[4] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: Data(corruptedBytes))
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "arr"])
+        }
+    }
+
+    func testStructWithCorruptDataOnKeyedNestedContainer() throws {
+        struct Test: Codable, Equatable {
+            enum CodingKeys: String, CodingKey {
+                case nested
+            }
+
+            enum NestedCodingKeys: String, CodingKey {
+                case bool
+            }
+
+            let bool: CorruptBool
+
+            init(bool: CorruptBool) {
+                self.bool = bool
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let nestedContainer = try container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .nested)
+                self.bool = try nestedContainer.decode(CorruptBool.self, forKey: .bool)
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .nested)
+                try nestedContainer.encode(bool, forKey: .bool)
+            }
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            14, // Byte length of val value
+            0b01101010, 110, 101, 115, 116, 101, 100, // String key 'nested', varint
+            6, // Byte length of nested value
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            0, // Corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(Test(bool: false)))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "bool"])
+        }
+    }
+
+    func testStructWithCorruptDataOnUnkeyedNestedContainer() throws {
+        struct TestWrapper: Codable, Equatable {
+            enum CodingKeys: String, CodingKey {
+                case nested
+            }
+
+            enum NestedCodingKeys: String, CodingKey {
+                case bool
+            }
+
+            let val: Test
+
+            init(val: Test) {
+                self.val = val
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = try container.nestedUnkeyedContainer(forKey: .nested)
+                self.val = try nestedContainer.decode(Test.self)
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = container.nestedUnkeyedContainer(forKey: .nested)
+                try nestedContainer.encode(val)
+            }
+        }
+        struct Test: Codable, Equatable {
+            let bool: CorruptBool
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            15, // Byte length of val value
+            0b01101010, 110, 101, 115, 116, 101, 100, // String key 'nested', varint
+            7, // Byte length of nested value
+            6, // Byte length of unkeyed container
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            0 // Corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(TestWrapper(val: Test(bool: false))))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<TestWrapper>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "0", "bool"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueAndWrongLengths() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Supposed byte length of optional val
+            1, // 1 optional,
+            6, // Supposed byte length of wrapped val
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueAndWrongNestedLength() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Byte length of optional val (modified!)
+            1, // 1 as in the optional is present,
+            6, // Supposed byte length of wrapped val
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data[4] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueButCorrectByteLengths() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Byte length of optional val (modified!)
+            1, // 1 as in the optional is present,
+            5, // Byte length of wrapped val (modified!)
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data[4] -= 1
+        data[6] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "bool"])
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 Motivation

When a data corruption error occurs, it's currently hard to tell what was responsible for the corruption. Beside indeed corrupted data, corruptions can be caused by mismatching `Encodable` and `Decodable` implementations, as well as internal errors of this library around the coding and decoding process.

`Codable` allows to maintain `codingPaths`, which is already partially implemented. However it is not fully utilized yet to indicate where an errors occurs throughout the decoding process.

This PR makes sure that all errors due to data corruption are annotated with the coding path of the currently decoded key. As all errors thrown are of the case `DecodingError.dataCorrupted`, it is sufficient to handle just said errors.

## 💪 How

This PR adds a private helper method `wrapError(forKey: _, _)` to `KeyedContainer`, which catches the relevant case of `DecodingError` and composes the path, based of the containers coding path, the given key and coding path already set on the error's context. This is done when decoding nested values (via `decode(_, forKey: _)`) and retrieving nested containers.
Note some limitations:
1. The `KeyedContainer` of BinaryCodable is eagerly reading all keys on initialization. If a container's data is syntactically invalid (e.g. keys or values of invalid length), then this will fail early. This is handled by additional error handling logic in the `KeyedContainer`'s initializer, but if a data corruption causes a byte length difference within a nested key or value, this cannot be indicated and is likely to cause an error at the next sibling or an ancestor in the tree.
2. The `KeyedContainer` does not include yet the super key on decoding errors within the coding path.

In similar fashion, this PR also utilizes now the private helper method `wrapError(_)` in `UnkeyedContainer`. This was previously unused. Further it does update said method's implementation, so that it does attribute the error to a coding path which includes the `currentIndex`. To achieve that, I've added a helper struct `AnyCodingKey` to the library, which is essentially a type-erased `CodingKey` allowing to represent arbitrary coding keys values without a concrete type.

## 🧪 Testing

To ensure the correctness of the added error handling, I've added a relatively comprehensive test case `CodingPathTests`. I have chosen a white box testing approach here, coming up with a series of tests cases which should ensure to hit all relevant code paths. I've done this by relying only on the public API by testing through decoding crafted corrupted data.

To achieve this, all tests:
1. Correctly encode their values with the data structure they define.
2. Programmatically mutate the binary representation.
3. Validate whether the so corrupted bytes do equal with the expected and documented binary representation.

This ensures that the tests stay maintainable, by being self-documenting and preventing that changes to the utilized data structure lead to cryptic failures, because the crafted corrupted data mismatches.

Within the tests, I've relied on some helpers structs:
1. `NestedBox<T>`: This is consistently used as the root value of all encoded values to ensure that there is at least one coding key `val` inherited throughout the coding path. This enables the tests to validate that this inheritance is correctly taking place.
2. `CorruptBool`: This type decodes a boolean `val`. If it is `true`, then it decodes without errors, but it throws a data corruption error when attempting to decode a `false` value. Once again, this is encoding/decoding to a keyed nested container to test that the presence of the coding key within the coding path.

Most tests rely on a single byte being removed or 1<>0 bit flips. While some of these tests might even cover useful real-world scenarios with correctly working encoding and decoding implementations, this is not given for all tests. Particularly when bytes were removed, some tests are also making sure to account for this in the encoded byte lengths to ensure that the error is only thrown for a coding path further nested in the tree. Such errors are obviously extremely unlikely to occur in the wild by chance. But this seems useful in development, when encoding and decoding implementations are likely to be not correctly aligned.