### PR TITLE
Decoding fails for optional varlength values in a singleValueContainer nested in keyed containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,6 @@ All possible errors occuring during encoding produce `EncodingError` errors, whi
 Both are the default Errors provided by Swift, supplied with information describing the nature of the error. 
 See the documentation of the types to learn more about the different error conditions.
 
-#### Unsupported features
-
-It is currently not supported to call `func encodeNil()` on `SingleValueEncodingContainer` for custom implementations of `func encode(to:)`.
-Future versions may include a special setting to enforce compatibility with this option.
-
 #### Handling corrupted data
 
 The [binary format](BinaryFormat.md) provides no provisions to detect data corruption, and various errors can occur as the result of added, changed, or missing bytes and bits. 

--- a/Sources/BinaryCodable/Common/AnyCodingKey.swift
+++ b/Sources/BinaryCodable/Common/AnyCodingKey.swift
@@ -1,0 +1,35 @@
+
+/// Helpful for appending mixed coding keys.
+struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = "\(intValue)"
+    }
+
+    init(stringValue: String) {
+        self.intValue = nil
+        self.stringValue = stringValue
+    }
+}
+
+extension AnyCodingKey {
+    init<T: CodingKey>(_ key: T) {
+        self.stringValue = key.stringValue
+        self.intValue = key.intValue
+    }
+}
+
+extension AnyCodingKey: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) {
+        self.init(stringValue: value)
+    }
+}
+
+extension AnyCodingKey: ExpressibleByIntegerLiteral {
+    init(integerLiteral value: Int) {
+        self.init(intValue: value)
+    }
+}

--- a/Sources/BinaryCodable/Decoding/KeyedDecoder.swift
+++ b/Sources/BinaryCodable/Decoding/KeyedDecoder.swift
@@ -10,12 +10,33 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
         while decoder.hasMoreBytes {
             let (key, dataType) = try DecodingKey.decode(from: decoder, path: path)
 
-            let data = try decoder.getData(for: dataType, path: path)
-
-            guard content[key] != nil else {
-                content[key] = [data]
-                continue
+            do {
+                let data = try decoder.getData(for: dataType, path: path)
+                guard content[key] != nil else {
+                    content[key] = [data]
+                    continue
+                }
+            } catch DecodingError.dataCorrupted(let context) {
+                let codingKey = {
+                    switch key {
+                    case .stringKey(let stringValue):
+                        return Key(stringValue: stringValue)
+                    case .intKey(let intValue):
+                        return Key(intValue: intValue)
+                    }
+                }()
+                var newCodingPath = path
+                if let codingKey {
+                    newCodingPath += [codingKey]
+                }
+                let newContext = DecodingError.Context(
+                    codingPath: newCodingPath,
+                    debugDescription: context.debugDescription,
+                    underlyingError: context.underlyingError
+                )
+                throw DecodingError.dataCorrupted(newContext)
             }
+
             throw DecodingError.multipleValuesForKey(path, key)
         }
         self.content = content.mapValues { parts in
@@ -60,27 +81,33 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
     }
 
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
-        let data = try getData(forKey: key)
-        if type is AnyOptional.Type {
-            let node = DecodingNode(data: data, isOptional: true, path: codingPath, info: userInfo)
-            return try T.init(from: node)
-        } else if let Primitive = type as? DecodablePrimitive.Type {
-            return try Primitive.init(decodeFrom: data, path: codingPath + [key]) as! T
-        } else {
-            let node = DecodingNode(data: data, path: codingPath, info: userInfo)
-            return try T.init(from: node)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            if type is AnyOptional.Type {
+                let node = DecodingNode(data: data, isOptional: true, path: codingPath, info: userInfo)
+                return try T.init(from: node)
+            } else if let Primitive = type as? DecodablePrimitive.Type {
+                return try Primitive.init(decodeFrom: data, path: codingPath + [key]) as! T
+            } else {
+                let node = DecodingNode(data: data, path: codingPath, info: userInfo)
+                return try T.init(from: node)
+            }
         }
     }
 
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        let data = try getData(forKey: key)
-        let container = try KeyedDecoder<NestedKey>(data: data, path: codingPath, info: userInfo)
-        return KeyedDecodingContainer(container)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            let container = try KeyedDecoder<NestedKey>(data: data, path: codingPath, info: userInfo)
+            return KeyedDecodingContainer(container)
+        }
     }
 
     func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        let data = try getData(forKey: key)
-        return try UnkeyedDecoder(data: data, path: codingPath, info: userInfo)
+        try wrapError(forKey: key) {
+            let data = try getData(forKey: key)
+            return try UnkeyedDecoder(data: data, path: codingPath, info: userInfo)
+        }
     }
 
     func superDecoder() throws -> Decoder {
@@ -91,5 +118,18 @@ final class KeyedDecoder<Key>: AbstractDecodingNode, KeyedDecodingContainerProto
     func superDecoder(forKey key: Key) throws -> Decoder {
         let data = try getData(forKey: key)
         return DecodingNode(data: data, path: codingPath, info: userInfo)
+    }
+
+    private func wrapError<T>(forKey key: Key, _ block: () throws -> T) throws -> T {
+        do {
+            return try block()
+        } catch DecodingError.dataCorrupted(let context) {
+            let newContext = DecodingError.Context(
+                codingPath: codingPath + [key] + context.codingPath,
+                debugDescription: context.debugDescription,
+                underlyingError: context.underlyingError
+            )
+            throw DecodingError.dataCorrupted(newContext)
+        }
     }
 }

--- a/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
@@ -18,7 +18,7 @@ class AbstractEncodingNode: AbstractNode {
         userInfo.has(.sortKeys)
     }
     
-    let containsOptional: Bool
+    var containsOptional: Bool
 
     init(path: [CodingKey], info: UserInfo, optional: Bool) {
         self.containsOptional = optional

--- a/Sources/BinaryCodable/Encoding/ValueEncoder.swift
+++ b/Sources/BinaryCodable/Encoding/ValueEncoder.swift
@@ -88,6 +88,10 @@ extension ValueEncoder: EncodingContainer {
         guard containsOptional else {
             return key.encode(for: container?.dataType ?? .byte) + (container?.dataWithLengthInformationIfRequired ?? .empty)
         }
+        guard !isNil else {
+            // Nothing to do, nil is ommited for keyed containers
+            return Data()
+        }
         let data = optionalData
         return key.encode(for: .variableLength) + data.count.variableLengthEncoding + optionalData
     }

--- a/Sources/BinaryCodable/Protocols/AnyOptional.swift
+++ b/Sources/BinaryCodable/Protocols/AnyOptional.swift
@@ -4,7 +4,7 @@ protocol AnyOptional {
 
     var isNil: Bool { get }
 
-    static var nilValue: Any { get }
+    static var nilValue: Self { get }
 }
 
 extension Optional: AnyOptional {
@@ -18,8 +18,8 @@ extension Optional: AnyOptional {
         }
     }
 
-    static var nilValue: Any {
-        return Self.none as Any
+    static var nilValue: Self {
+        return Self.none
     }
 
 }

--- a/Tests/BinaryCodableTests/CodingPathTests.swift
+++ b/Tests/BinaryCodableTests/CodingPathTests.swift
@@ -1,0 +1,339 @@
+import XCTest
+import BinaryCodable
+
+final class CodingPathTests: XCTestCase {
+
+    struct KeyedBox<T: Codable>: Codable {
+        enum CodingKeys: String, CodingKey {
+            case val
+        }
+
+        let val: T
+
+        init(_ val: T) {
+            self.val = val
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.val = try container.decode(T.self, forKey: .val)
+        }
+    }
+
+    struct CorruptBool: Codable, Equatable, ExpressibleByBooleanLiteral {
+        let val: Bool
+
+        init(booleanLiteral value: BooleanLiteralType) {
+            self.val = value
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.val = try container.decode(Bool.self)
+            if val == false {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Found false!")
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(val)
+        }
+    }
+
+    func testStructWithCorruptArrayElement() throws {
+        struct Test: Codable, Equatable {
+            let arr: [CorruptBool]
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1, 0 // True, true, corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "arr", "2"])
+        }
+    }
+
+    func testStructWithArrayMissingLastElement() throws {
+        struct Test: Codable, Equatable {
+            let arr: [Bool]
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1 // Only two elements provided!
+        ]
+
+        var data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: Data(corruptedBytes))
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testStructWithArrayMissingLastElementButCorrectLength() throws {
+        struct Test: Codable, Equatable {
+            let arr: [Bool]
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Length of val
+            0b00111010, 97, 114, 114, // String key 'arr', varint
+            3, // 3 elements
+            1, 1 // Only two elements provided!
+        ]
+
+        var data = try BinaryEncoder().encode(KeyedBox(Test(arr: [true, true, false])))
+        data[4] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: Data(corruptedBytes))
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "arr"])
+        }
+    }
+
+    func testStructWithCorruptDataOnKeyedNestedContainer() throws {
+        struct Test: Codable, Equatable {
+            enum CodingKeys: String, CodingKey {
+                case nested
+            }
+
+            enum NestedCodingKeys: String, CodingKey {
+                case bool
+            }
+
+            let bool: CorruptBool
+
+            init(bool: CorruptBool) {
+                self.bool = bool
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let nestedContainer = try container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .nested)
+                self.bool = try nestedContainer.decode(CorruptBool.self, forKey: .bool)
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .nested)
+                try nestedContainer.encode(bool, forKey: .bool)
+            }
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            14, // Byte length of val value
+            0b01101010, 110, 101, 115, 116, 101, 100, // String key 'nested', varint
+            6, // Byte length of nested value
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            0, // Corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(Test(bool: false)))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "bool"])
+        }
+    }
+
+    func testStructWithCorruptDataOnUnkeyedNestedContainer() throws {
+        struct TestWrapper: Codable, Equatable {
+            enum CodingKeys: String, CodingKey {
+                case nested
+            }
+
+            enum NestedCodingKeys: String, CodingKey {
+                case bool
+            }
+
+            let val: Test
+
+            init(val: Test) {
+                self.val = val
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = try container.nestedUnkeyedContainer(forKey: .nested)
+                self.val = try nestedContainer.decode(Test.self)
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                var nestedContainer = container.nestedUnkeyedContainer(forKey: .nested)
+                try nestedContainer.encode(val)
+            }
+        }
+        struct Test: Codable, Equatable {
+            let bool: CorruptBool
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            15, // Byte length of val value
+            0b01101010, 110, 101, 115, 116, 101, 100, // String key 'nested', varint
+            7, // Byte length of nested value
+            6, // Byte length of unkeyed container
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            0 // Corrupt!
+        ]
+
+        let data = try BinaryEncoder().encode(KeyedBox(TestWrapper(val: Test(bool: false))))
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<TestWrapper>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "0", "bool"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueAndWrongLengths() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            8, // Supposed byte length of optional val
+            1, // 1 optional,
+            6, // Supposed byte length of wrapped val
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueAndWrongNestedLength() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+        
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Byte length of optional val (modified!)
+            1, // 1 as in the optional is present,
+            6, // Supposed byte length of wrapped val
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data[4] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val"])
+        }
+    }
+
+    func testOptionalStructWithMissingValueButCorrectByteLengths() throws {
+        struct Test: Codable, Equatable {
+            let bool: Bool
+        }
+
+        let corruptedBytes: [UInt8] = [
+            0b00111010, 118, 97, 108, // String key 'val', varint
+            7, // Byte length of optional val (modified!)
+            1, // 1 as in the optional is present,
+            5, // Byte length of wrapped val (modified!)
+            0b01001000, 98, 111, 111, 108, // String key 'bool', varint
+            // No value!
+        ]
+
+        let box: KeyedBox<Test?> = KeyedBox(Test(bool: true))
+
+        var data = try BinaryEncoder().encode(box)
+        data[4] -= 1
+        data[6] -= 1
+        data.removeLast()
+        XCTAssertEqual(Array(data), corruptedBytes)
+
+        do {
+            let _ = try BinaryDecoder().decode(KeyedBox<Test?>.self, from: data)
+            XCTFail("Unexpected succeded!")
+        } catch let error as DecodingError {
+            guard case .dataCorrupted(let context) = error else {
+                XCTFail("Unexpected error!")
+                return
+            }
+            XCTAssertEqual(context.codingPath.map { $0.stringValue }, ["val", "bool"])
+        }
+    }
+}

--- a/Tests/BinaryCodableTests/OptionalEncodingTests.swift
+++ b/Tests/BinaryCodableTests/OptionalEncodingTests.swift
@@ -60,7 +60,7 @@ final class OptionalEncodingTests: XCTestCase {
 
     func testClassWithOptionalProperty() throws {
         let item = TestClass(withName: "Bob", endDate: nil)
-        try compare(item, to: [18, 3, 66, 111, 98, 34, 1, 0], sort: true)
+        try compare(item, to: [18, 3, 66, 111, 98], sort: true)
 
         let item2 = TestClass(withName: "Bob", endDate: "s")
         try compare(item2, to: [18, 3, 66, 111, 98, 34, 3, 1, 1, 115], sort: true)

--- a/Tests/BinaryCodableTests/OptionalEncodingTests.swift
+++ b/Tests/BinaryCodableTests/OptionalEncodingTests.swift
@@ -14,6 +14,13 @@ final class OptionalEncodingTests: XCTestCase {
         try compareEncoding(Bool?.self, value: nil, to: [0])
     }
 
+    func testDoubleOptionalBoolEncoding() throws {
+        try compareEncoding(Bool??.self, value: .some(.some(true)), to: [1, 1, 1])
+        try compareEncoding(Bool??.self, value: .some(.some(false)), to: [1, 1, 0])
+        try compareEncoding(Bool??.self, value: .some(.none), to: [1, 0])
+        try compareEncoding(Bool??.self, value: .none, to: [0])
+    }
+
     func testOptionalStruct() throws {
         struct T: Codable, Equatable {
             var a: Int

--- a/Tests/BinaryCodableTests/PropertyWrapperCodingTests.swift
+++ b/Tests/BinaryCodableTests/PropertyWrapperCodingTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+import BinaryCodable
+
+/// While from the perspective of `Codable` nothing about property wrapper is special,
+/// they tend to encode their values via `singleValueContainer()`, which requires
+/// some considerations when it comes to dealing with optionals.
+///
+final class PropertyWrapperCodingTests: XCTestCase {
+    struct KeyedWrapper<T: Codable & Equatable>: Codable, Equatable {
+        enum CodingKeys: String, CodingKey {
+            case wrapper
+        }
+
+        @Wrapper
+        var value: T
+
+        init(_ value: T) {
+            self._value = Wrapper(wrappedValue: value)
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self._value = try container.decode(Wrapper<T>.self, forKey: .wrapper)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(_value, forKey: .wrapper)
+        }
+    }
+
+    @propertyWrapper
+    struct Wrapper<T: Codable & Equatable>: Codable, Equatable {
+        let wrappedValue: T
+
+        init(wrappedValue: T) {
+            self.wrappedValue = wrappedValue
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.wrappedValue = try container.decode(T.self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(wrappedValue)
+        }
+    }
+
+    struct WrappedString: Codable, Equatable {
+        let val: String
+    }
+
+    func assert<T: Codable & Equatable>(
+        encoding wrapped: T,
+        as type: T.Type = T.self,
+        expectByteSuffix byteSuffix: [UInt8],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let bytePrefix: [UInt8] = [
+            0b01111010, 119, 114, 97, 112, 112, 101, 114, // String key 'wrapper', varint,
+        ]
+
+        let wrapper = KeyedWrapper<T>(wrapped)
+        let data = try BinaryEncoder.encode(wrapper)
+
+        // If the prefix differs, this error affects the test helper, so report it here
+        XCTAssertEqual(Array(data.prefix(bytePrefix.count)), bytePrefix)
+
+        // If the suffix differs, this error is specific to the individual test case,
+        // so report it on the call-side
+        XCTAssertEqual(Array(data.suffix(from: bytePrefix.count)), byteSuffix, file: file, line: line)
+
+        let decodedWrapper: KeyedWrapper<T> = try BinaryDecoder.decode(from: data)
+        XCTAssertEqual(decodedWrapper, wrapper, file: file, line: line)
+    }
+
+    func testOptionalWrappedStringSome() throws {
+        try assert(
+            encoding: WrappedString(val: "Some"),
+            as: WrappedString?.self,
+            expectByteSuffix: [
+                11, // Length 11
+                1, // 1 as in the optional is present
+                9, // Length 9
+                0b00111010, 118, 97, 108, // String key 'val', varint
+                4, // Length 4,
+                83, 111, 109, 101, // String "Some"
+            ]
+        )
+    }
+
+    func testOptionalWrappedStringNone() throws {
+        try assert(
+            encoding: nil,
+            as: WrappedString?.self,
+            expectByteSuffix: [
+                1, // Length 1
+                0, // Optional is absent
+            ]
+        )
+    }
+
+    func testOptionalBool() throws {
+        try assert(
+            encoding: .some(true),
+            as: Bool?.self,
+            expectByteSuffix: [
+                2, // Length 2
+                1, // Optional is present
+                1, // Boolean is true
+            ]
+        )
+
+        try assert(
+            encoding: .some(false),
+            as: Bool?.self,
+            expectByteSuffix: [
+                2, // Length 2
+                1, // Optional is present
+                0, // Boolean is false
+            ]
+        )
+
+        try assert(
+            encoding: nil,
+            as: Bool?.self,
+            expectByteSuffix: [
+                1, // Length 1
+                0, // Optional is present
+            ]
+        )
+    }
+
+    func testDoubleOptionalBool() throws {
+        try assert(
+            encoding: .some(.some(true)),
+            as: Bool??.self,
+            expectByteSuffix: [3, 1, 1, 1]
+        )
+
+        try assert(
+            encoding: .some(.some(false)),
+            as: Bool??.self,
+            expectByteSuffix: [3, 1, 1, 0]
+        )
+
+        try assert(
+            encoding: .some(nil),
+            as: Bool??.self,
+            expectByteSuffix: [2, 1, 0]
+        )
+
+        try assert(
+            encoding: nil,
+            as: Bool??.self,
+            expectByteSuffix: [1, 0]
+        )
+    }
+}


### PR DESCRIPTION
## 🐛 Issue

With the help of my work in #10, I realized that #9 didn't fully address corruptions which can occur around encoding values in singleValueContainers when they are used in keyed containers. Particularly optional varlength values in a single-value container encode to corrupted binary representations.

This seems loosely related to the limitation, which is also stated in the readme:
>It is currently not supported to call `func encodeNil()` on `SingleValueEncodingContainer` for custom implementations of `func encode(to:)`.

However I don't think this note would state the full extent of the issue clearly enough, as not just encoding `nil`, but also encoding an optional value is under certain conditions unsupported. Also the `fatalError` in `ValueEncoder.encodeNil` has not been triggered in this situation, which I understand is supposed to stop a developer from using this library in an unsupported way.

## 🍒 Example

As the conditions of this behavior seem quite particular and rather difficult to understand, let me illustrate with an example.
Consider the following data structures:
```swift
struct KeyedWrapper<T: Codable & Equatable>: Codable, Equatable {
    @Wrapper
    var value: T
}

@propertyWrapper
struct Wrapper<T: Codable & Equatable>: Codable, Equatable {
    let wrappedValue: T

    init(from decoder: Decoder) throws {
        let container = try decoder.singleValueContainer()
        self.wrappedValue = try container.decode(T.self)
    }

    func encode(to encoder: Encoder) throws {
        var container = encoder.singleValueContainer()
        try container.encode(wrappedValue)
    }
}
```
>**Note:** I'm using a property wrapper here to illustrate this behavior. This is not because this behavior would only reproduce with a property wrapper, but rather because I could infer this demo based on real-world code, where a property wrapper `Box` was being used to allow a recursive data structure by indirection.

This type would have not been properly decoded before my fix with #9. It can be properly decoded now for non-optional values.

I realized with further testing, that this still does not properly encode or decode though when the generic argument `T` is an `Optional` and the value is not a primitive of fixed length (e.g. `Bool`, etc.), but rather a value of variable length, as in that case the byte count is not encoded.

In concrete, the following code:
```swift
let wrapper: KeyedWrapper<String?> = KeyedWrapper(value: "Some")
let data = try BinaryEncoder.encode(wrapper)
```

Results in the following binary representation:
```diff
0b1011010, 118, 97, 108, 117, 101, // String key 'value', varint,
- 6 // Byte count of the optional data 
1, // Optional is present
4, // Byte length of string
83, 111, 109, 101 // String 'Some'
```

This fails to decode, because a `varint` key is expected to decode the full data of the key's value by first decoding the length, because the decoding is at this step agnostic about the syntax of the value beyond the data type.

So what happens when decoding this, is that `1` is interpreted as the byte count of the `value` key. Next up the contained string will be interpreted as next key, which results in this example in a data corruption error with the reason `Unknown data type 3` as the capital `S` happens to be encoded with `0b...11` as least significant bits, which are used to encode the data type.

This also fails when encoding any `KeyedWrapper(value: nil)`. It results in the following binary representation:
```diff
0b1011010, 118, 97, 108, 117, 101, // String key 'value', varint,
-1 // Byte count of the optional data
0 // Optional is absent
```

This fails to decode, because again a `varint` key would be expected to decode the length first, which in case of an absent optional should be a byte count of `1` and `0` to signify the absence of a value. Instead this would result in a data corruption error with the reason `Premature end of data`.

This second example can be considered essentially as equivalent to invoking `encodeNil` on a `singleValueContainer`, which the readme does state as a limitation. So I've wondered if such a data type is outside of what this library does support.

**In practice, this can throw other errors, try to decode a value when a `nil` value was encoded, or even succeed decoding wrong data.**

## 💪 Solution

This PR detects when encoding an optional value via a `singleValueContainer` and memorizes this via setting a new property `containerHasOptionalContent` on the `ValueContainer`. This property is considered when the data of the container is encoded for a key, so in the context of a keyed container, so that in this case the count byte is encoded – and so that the value held by the container is not encoded as an optional again.

Also it makes `containsOptional` mutable, so that when `encodeNil` is used, this can be set to `true` which is necessary particularly in the situation of encoding optional data in a keyed container.

In general, these changes do introduce additional mutable state to the encoder, which is unfortunate, as it makes it harder to reason about the correctness of the implementation.

I deemed that this is a sensible scenario to expand testing on, which I've done with the additional tests `PropertyWrapperCodingTests`. While, as explained in a comment in the tests as well, this has little to do with property wrappers per-se, they seem a common enough use case of `singleValueContainers` in `Codable` implementations, so that this is also helpful by further documenting which considerations are made by `BinaryCodable` and how it can be used.

According to SemVer, this change should only require a patch-level bump of the version of this library as it should not affect the binary representations of data structures, which were previously fully encodable and decodable.

## ⚡ Related Changes

Further this PR also ensures that absent optional key-value pairs via `singleValueContainer`/`ValueContainer` are omitted and not encoded with an empty key. This would have previously resulted in additional bytes in the binary: `<KEY> 1 0`.
The new behavior is similar to the behavior of `KeyedContainer.encodeNil(forKey: _)` and such more consistent, as using a `singleValueContainer` should be considered an implementation detail and not result in changes of the binary representation.

This change required also a change to the decoding of the `KeyedContainer`. If an optional value `T` is decoded for a key via `decode(T?.self, forKey: _)` instead of via `decodeIfPresent(T.self, forKey: _)`, this does now not fail the decoding anymore if the optional value is absent. To achieve that, I've changed the type of `AnyOptional`'s `nilValue` to `Self` instead of `Any`. However as Swift's type system doesn't allow to cast a type value to a composed metatype, something like `type as? T.Type & AnyOptional.Type`, this still requires a force-cast from `type.nilValue` to `T`.

The change to the encoding further reduces the encoded binary size, which does seem a general goal of this library.

This change is backwards compatible in the sense that existing binary representations can be still decoded, but if this is shipped, existing implementations will fail to decode binary representations encoded by newer versions, omitting keys. Depending on whether the previous inconsistent behavior is considered intentional or a bug, this should be either released with a minor version bump or a patch version bump of this library, according to SemVer.

## 🛟 Limitations Resolved?

This solution does resolve the earlier quoted limitation around encoding `nil` to my understanding entirely, so I also allowed myself to also remove this hint from the readme. As the hint in the readme had detailed that you might consider to add _a special setting_ to support this, I've been wondering if you see any further changes or even format breaking changes necessary to be able to fully support optional/nil coding on `singleValueContainer`. I've tried to test this already quite exhaustively, but I am probably missing further relevant test scenarios. So if you have any ideas on how this change could break, please let me know.
