### PR TITLE
Fix wrapper encoding for other encoders

### DIFF
--- a/Sources/BinaryCodable/Wrappers/FixedSizeEncoded.swift
+++ b/Sources/BinaryCodable/Wrappers/FixedSizeEncoded.swift
@@ -249,7 +249,7 @@ extension FixedSizeEncoded: Encodable {
      */
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self)
+        try container.encode(wrappedValue)
     }
 }
 
@@ -261,6 +261,6 @@ extension FixedSizeEncoded: Decodable {
      */
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = try container.decode(Self.self)
+        wrappedValue = try container.decode(WrappedValue.self)
     }
 }

--- a/Sources/BinaryCodable/Wrappers/VariableLengthCodable.swift
+++ b/Sources/BinaryCodable/Wrappers/VariableLengthCodable.swift
@@ -8,7 +8,7 @@ public typealias VariableLengthCodable = VariableLengthEncodable & VariableLengt
 /**
  A type that can be encoded as a variable-length integer
  */
-public protocol VariableLengthEncodable: FixedWidthInteger {
+public protocol VariableLengthEncodable: FixedWidthInteger, Encodable {
 
     /// The value encoded as binary data using variable-length integer encoding
     var variableLengthEncoding: Data { get }
@@ -17,7 +17,7 @@ public protocol VariableLengthEncodable: FixedWidthInteger {
 /**
  A type that can be decoded as a variable-length integer
  */
-public protocol VariableLengthDecodable: FixedWidthInteger {
+public protocol VariableLengthDecodable: FixedWidthInteger, Decodable {
 
     /**
      Decode a value as a variable-length integer.

--- a/Sources/BinaryCodable/Wrappers/VariableLengthEncoded.swift
+++ b/Sources/BinaryCodable/Wrappers/VariableLengthEncoded.swift
@@ -257,7 +257,7 @@ extension VariableLengthEncoded: Encodable {
      */
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self)
+        try container.encode(wrappedValue)
     }
 }
 
@@ -269,6 +269,6 @@ extension VariableLengthEncoded: Decodable {
      */
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = try container.decode(Self.self)
+        wrappedValue = try container.decode(WrappedValue.self)
     }
 }

--- a/Sources/BinaryCodable/Wrappers/ZigZagCodable.swift
+++ b/Sources/BinaryCodable/Wrappers/ZigZagCodable.swift
@@ -12,7 +12,7 @@ public typealias ZigZagCodable = ZigZagEncodable & ZigZagDecodable
 /**
  A type that can be encoded as a zig-zag variable-length integer
  */
-public protocol ZigZagEncodable {
+public protocol ZigZagEncodable: Encodable {
 
     /// The value encoded as binary data using zig-zag variable-length integer encoding
     var zigZagEncoded: Data { get }
@@ -22,7 +22,7 @@ public protocol ZigZagEncodable {
 /**
  A type that can be decoded as a zig-zag variable-length integer
  */
-public protocol ZigZagDecodable {
+public protocol ZigZagDecodable: Decodable {
 
     /**
      Decode a value as a zig-zag variable-length integer.

--- a/Sources/BinaryCodable/Wrappers/ZigZagEncoded.swift
+++ b/Sources/BinaryCodable/Wrappers/ZigZagEncoded.swift
@@ -257,7 +257,7 @@ extension ZigZagEncoded: Encodable {
      */
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self)
+        try container.encode(wrappedValue)
     }
 }
 
@@ -269,6 +269,6 @@ extension ZigZagEncoded: Decodable {
      */
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = try container.decode(Self.self)
+        wrappedValue = try container.decode(WrappedValue.self)
     }
 }

--- a/Tests/BinaryCodableTests/WrapperEncodingTests.swift
+++ b/Tests/BinaryCodableTests/WrapperEncodingTests.swift
@@ -244,4 +244,76 @@ final class WrapperEncodingTests: XCTestCase {
             123 // Int 123, variable-length encoded
         ])
     }
+
+    /**
+     This test ensures that the fixed wrapper is transparent for other encoders
+     */
+    func testEncodeFixedWrapperWithJSON() throws {
+        struct Test: Codable, Equatable {
+            @FixedSizeEncoded
+            var val: Int
+        }
+
+        struct Test2: Codable, Equatable {
+            var val: Int
+        }
+
+        let value = Test(val: 123)
+        let value2 = Test2(val: 123)
+        let encoded = try JSONEncoder().encode(value)
+        let encoded2 = try JSONEncoder().encode(value2)
+        XCTAssertEqual(encoded, encoded2)
+        let decoded = try JSONDecoder().decode(Test.self, from: encoded)
+        let decoded2 = try JSONDecoder().decode(Test2.self, from: encoded2)
+        XCTAssertEqual(decoded, value)
+        XCTAssertEqual(decoded2, value2)
+    }
+
+    /**
+     This test ensures that the zig-zag wrapper is transparent for other encoders
+     */
+    func testEncodeZigZagWrapperWithJSON() throws {
+        struct Test: Codable, Equatable {
+            @ZigZagEncoded
+            var val: Int16
+        }
+
+        struct Test2: Codable, Equatable {
+            var val: Int16
+        }
+
+        let value = Test(val: 123)
+        let value2 = Test2(val: 123)
+        let encoded = try JSONEncoder().encode(value)
+        let encoded2 = try JSONEncoder().encode(value2)
+        XCTAssertEqual(encoded, encoded2)
+        let decoded = try JSONDecoder().decode(Test.self, from: encoded)
+        let decoded2 = try JSONDecoder().decode(Test2.self, from: encoded2)
+        XCTAssertEqual(decoded, value)
+        XCTAssertEqual(decoded2, value2)
+    }
+
+    /**
+     This test ensures that the variable length wrapper is transparent for other encoders
+     */
+    func testEncodeVariableLengthWrapperWithJSON() throws {
+        struct Test: Codable, Equatable {
+            @VariableLengthEncoded
+            var val: Int
+        }
+
+        struct Test2: Codable, Equatable {
+            var val: Int
+        }
+
+        let value = Test(val: 123)
+        let value2 = Test2(val: 123)
+        let encoded = try JSONEncoder().encode(value)
+        let encoded2 = try JSONEncoder().encode(value2)
+        XCTAssertEqual(encoded, encoded2)
+        let decoded = try JSONDecoder().decode(Test.self, from: encoded)
+        let decoded2 = try JSONDecoder().decode(Test2.self, from: encoded2)
+        XCTAssertEqual(decoded, value)
+        XCTAssertEqual(decoded2, value2)
+    }
 }


### PR DESCRIPTION
This PR fixes issues with wrappers like `@FixedSizeEncoded` when using them with other encoders like `JSONEncoder`.