### PR TITLE
Improve performance for large properties

### DIFF
--- a/Sources/BinaryCodable/BinaryStreamEncoder.swift
+++ b/Sources/BinaryCodable/BinaryStreamEncoder.swift
@@ -77,6 +77,8 @@ public final class BinaryStreamEncoder<Element> where Element: Encodable {
      - Throws: Errors of type `EncodingError`
      */
     public func encode<S>(contentsOf sequence: S) throws -> Data where S: Sequence, S.Element == Element {
-        try sequence.map(encode).joinedData
+        try sequence.mapAndJoin { value in
+            try self.encode(value)
+        }
     }
 }

--- a/Sources/BinaryCodable/Encoding/CodingKey+Encoding.swift
+++ b/Sources/BinaryCodable/Encoding/CodingKey+Encoding.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension CodingKey {
+
+    /**
+     Returns the encoded data for the key.
+     - Returns: The encoded data, or `nil`, if the integer coding key is invalid.
+     */
+    func keyData() -> Data? {
+        // String or Int key bit
+        // Length of String key or Int key as varint
+        // String Key Data
+        guard let intValue else {
+            let stringData = stringValue.data(using: .utf8)!
+            // Set String bit to 1
+            let lengthValue = (UInt64(stringData.count) << 1) + 0x01
+            let lengthData = lengthValue.variableLengthEncoding
+            return lengthData + stringData
+        }
+        guard intValue >= 0 else {
+            return nil
+        }
+        // For integer keys:
+        // The LSB is set to 0
+        // Encode 2 * intValue
+        return intValue.lengthData
+    }
+}

--- a/Sources/BinaryCodable/Encoding/EncodableContainer.swift
+++ b/Sources/BinaryCodable/Encoding/EncodableContainer.swift
@@ -26,13 +26,6 @@ protocol EncodableContainer {
 extension EncodableContainer {
 
     /**
-
-     */
-    func completeData(with key: CodingKey, codingPath: [CodingKey]) throws -> Data {
-        try key.keyData(codingPath: codingPath) + completeData()
-    }
-
-    /**
      The full data encoded in the container, including nil indicator and length, if needed
      */
     func completeData() throws -> Data {
@@ -52,38 +45,5 @@ extension EncodableContainer {
             return Data([0x00]) + data
         }
         return data
-    }
-}
-
-private extension Int {
-
-    /// Encodes the integer as the length of a nil/length indicator
-    var lengthData: Data {
-        // The first bit (LSB) is the `nil` bit (0)
-        // The rest is the length, encoded as a varint
-        (UInt64(self) << 1).encodedData
-    }
-}
-
-private extension CodingKey {
-
-    func keyData(codingPath: [CodingKey]) throws -> Data {
-        // String or Int key bit
-        // Length of String key or Int key as varint
-        // String Key Data
-        guard let intValue else {
-            let stringData = stringValue.data(using: .utf8)!
-            // Set String bit to 1
-            let lengthValue = (UInt64(stringData.count) << 1) + 0x01
-            let lengthData = lengthValue.encodedData
-            return lengthData + stringData
-        }
-        guard intValue >= 0 else {
-            throw EncodingError.invalidValue(intValue, .init(codingPath: codingPath + [self], debugDescription: "Invalid integer value for coding key"))
-        }
-        // For integer keys:
-        // The LSB is set to 0
-        // Encode 2 * intValue
-        return intValue.lengthData
     }
 }

--- a/Sources/BinaryCodable/Encoding/Int+Length.swift
+++ b/Sources/BinaryCodable/Encoding/Int+Length.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Int {
+
+    /// Encodes the integer as the length of a nil/length indicator
+    var lengthData: Data {
+        // The first bit (LSB) is the `nil` bit (0)
+        // The rest is the length, encoded as a varint
+        (UInt64(self) << 1).encodedData
+    }
+}

--- a/Sources/BinaryCodable/Encoding/KeyedEncoder.swift
+++ b/Sources/BinaryCodable/Encoding/KeyedEncoder.swift
@@ -79,8 +79,12 @@ extension KeyedEncoder: EncodableContainer {
     }
 
     private func encode<T>(elements: T) throws -> Data where T: Collection, T.Element == (key: HashableKey, value: EncodableContainer) {
-        try elements.map { key, value in
-            try value.completeData(with: key.key, codingPath: codingPath)
-        }.joinedData
+        try elements.mapAndJoin { key, value in
+            guard let keyData = key.key.keyData() else {
+                throw EncodingError.invalidValue(key.key.intValue!, .init(codingPath: codingPath + [key.key], debugDescription: "Invalid integer value for coding key"))
+            }
+            let data = try value.completeData()
+            return keyData + data
+        }
     }
 }

--- a/Sources/BinaryCodable/Encoding/PrimitiveEncodingContainer.swift
+++ b/Sources/BinaryCodable/Encoding/PrimitiveEncodingContainer.swift
@@ -15,7 +15,7 @@ struct PrimitiveEncodingContainer: EncodableContainer {
         self.wrapped = wrapped
     }
 
-    func containedData() throws -> Data {
+    func containedData() -> Data {
         wrapped.encodedData
     }
 }

--- a/Sources/BinaryCodable/Encoding/UnkeyedEncoder.swift
+++ b/Sources/BinaryCodable/Encoding/UnkeyedEncoder.swift
@@ -53,9 +53,8 @@ extension UnkeyedEncoder: EncodableContainer {
     }
 
     func containedData() throws -> Data {
-        try encodedValues.map {
-            let data = try $0.completeData()
-            return data
-        }.joinedData
+        try encodedValues.mapAndJoin {
+            try $0.completeData()
+        }
     }
 }

--- a/Sources/BinaryCodable/Extensions/Data+Extensions.swift
+++ b/Sources/BinaryCodable/Extensions/Data+Extensions.swift
@@ -18,6 +18,18 @@ extension Data {
     }
 }
 
+extension Sequence {
+
+    func mapAndJoin(_ closure: (Element) throws -> Data) rethrows -> Data {
+        var result = Data()
+        for (value) in self {
+            let data = try closure(value)
+            result.append(data)
+        }
+        return result
+    }
+}
+
 extension Sequence where Element: Sequence, Element.Element == UInt8 {
 
     var joinedData: Data {

--- a/Sources/BinaryCodable/Primitives/Int64+Coding.swift
+++ b/Sources/BinaryCodable/Primitives/Int64+Coding.swift
@@ -71,7 +71,7 @@ extension Int64: VariableLengthEncodable {
 
     /// The value encoded using variable length encoding
     public var variableLengthEncoding: Data {
-        UInt64(bitPattern: self).encodedData
+        UInt64(bitPattern: self).variableLengthEncoding
     }
 
 }

--- a/Tests/BinaryCodableTests/SequenceEncoderTests.swift
+++ b/Tests/BinaryCodableTests/SequenceEncoderTests.swift
@@ -6,7 +6,7 @@ final class SequenceEncoderTests: XCTestCase {
     private func encodeSequence<T>(_ input: Array<T>) throws where T: Codable, T: Equatable {
         let encoder = BinaryStreamEncoder<T>()
 
-        let bytes = try input.map(encoder.encode).joinedData
+        let bytes = try input.mapAndJoin(encoder.encode)
         print(Array(bytes))
         let decoder = BinaryStreamDecoder<T>()
 


### PR DESCRIPTION
Resolves issue #20.

The issue seems to come from copying `Data` elements multiple times during encoding, which adds a huge performance penalty when large properties are involved.