### PR TITLE
Allow multiple calls to containers

### DIFF
--- a/Sources/BinaryCodable/Decoding/DecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/DecodingNode.swift
@@ -7,31 +7,23 @@ final class DecodingNode: AbstractDecodingNode, Decoder {
 
     private let data: Data?
 
-    private var didCallContainer = false
-
     init(data: Data?, parentDecodedNil: Bool, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) throws {
         self.data = data
         super.init(parentDecodedNil: parentDecodedNil, codingPath: codingPath, userInfo: userInfo)
     }
 
-    private func registerContainer() throws {
-        guard !didCallContainer else {
-            throw DecodingError.corrupted("Multiple containers requested from decoder", codingPath: codingPath)
-        }
-        didCallContainer = true
-    }
-
     private func getNonNilElement() throws -> Data {
-        try registerContainer()
         // Non-root containers just use the data, which can't be nil
         guard let data else {
-            throw DecodingError.corrupted("Container requested, but nil found", codingPath: codingPath)
+            throw DecodingError.corrupted("Container requested, but `nil` found", codingPath: codingPath)
         }
         return data
     }
 
+    /**
+     Decode an element that can potentially be `nil` for a single value container.
+     */
     private func getPotentialNilElement() throws -> Data? {
-        try registerContainer()
         guard !parentDecodedNil else {
             return data
         }

--- a/Sources/BinaryCodable/Encoding/EncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/EncodingNode.swift
@@ -2,30 +2,47 @@ import Foundation
 
 final class EncodingNode: AbstractEncodingNode, Encoder {
 
-    private var hasMultipleCalls = false
-
     private var encodedValue: EncodableContainer? = nil
 
-    private func assign<T>(_ value: T) -> T where T: EncodableContainer {
-        // Prevent multiple calls to container(keyedBy:), unkeyedContainer(), or singleValueContainer()
-        if encodedValue == nil {
-            encodedValue = value
-        } else {
-            hasMultipleCalls = true
-        }
-        return value
-    }
-
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        return KeyedEncodingContainer(assign(KeyedEncoder<Key>(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)))
+        guard let encodedValue else {
+            let storage = KeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
+            self.encodedValue = storage
+            return KeyedEncodingContainer(KeyedEncoder(storage: storage))
+        }
+        guard let storage = encodedValue as? KeyedEncoderStorage else {
+            fatalError("Call to container(keyedBy:) after already calling unkeyedContainer() or singleValueContainer()")
+        }
+        return KeyedEncodingContainer(KeyedEncoder(storage: storage))
     }
 
     func unkeyedContainer() -> UnkeyedEncodingContainer {
-        return assign(UnkeyedEncoder(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo))
+        guard let encodedValue else {
+            let storage = UnkeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
+            self.encodedValue = storage
+            return UnkeyedEncoder(storage: storage)
+        }
+        guard let storage = encodedValue as? UnkeyedEncoderStorage else {
+            fatalError("Call to unkeyedContainer() after already calling container(keyedBy:) or singleValueContainer()")
+        }
+        return UnkeyedEncoder(storage: storage)
     }
 
     func singleValueContainer() -> SingleValueEncodingContainer {
-        return assign(ValueEncoder(codingPath: codingPath, userInfo: userInfo))
+        guard let encodedValue else {
+            // No previous container generated, create the storage
+            // and return a wrapper to it
+            let storage = ValueEncoderStorage(codingPath: codingPath, userInfo: userInfo)
+            self.encodedValue = storage
+            return ValueEncoder(storage: storage)
+        }
+        guard let storage = encodedValue as? ValueEncoderStorage else {
+            fatalError("Call to singleValueContainer() after already calling unkeyedContainer() or container(keyedBy:)")
+        }
+        // Multiple calls to singleValueContainer()
+        // Return a wrapper with the same underlying storage
+        // The last value encoded to any of the wrappers will be used
+        return ValueEncoder(storage: storage)
     }
 }
 
@@ -42,9 +59,6 @@ extension EncodingNode: EncodableContainer {
     }
 
     func containedData() throws -> Data {
-        guard !hasMultipleCalls else {
-            throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "Multiple calls to container(keyedBy:), unkeyedContainer(), or singleValueContainer()"))
-        }
         guard let encodedValue else {
             throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "No calls to container(keyedBy:), unkeyedContainer(), or singleValueContainer()"))
         }

--- a/Sources/BinaryCodable/Encoding/KeyedEncoderStorage.swift
+++ b/Sources/BinaryCodable/Encoding/KeyedEncoderStorage.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+final class KeyedEncoderStorage: AbstractEncodingNode {
+
+    private var encodedValues: [HashableKey : EncodableContainer] = [:]
+
+    @discardableResult
+    private func assign<T>(_ value: T, forKey key: CodingKey) -> T where T: EncodableContainer {
+        let hashableKey = HashableKey(key: key)
+        encodedValues[hashableKey] = value
+        return value
+    }
+
+    func assignedNode(forKey key: CodingKey) -> EncodingNode {
+        let node = EncodingNode(needsLengthData: true, codingPath: codingPath + [key], userInfo: userInfo)
+        return assign(node, forKey: key)
+    }
+
+    func superEncoder() -> Encoder {
+        assignedNode(forKey: SuperCodingKey())
+    }
+
+    func superEncoder(forKey key: CodingKey) -> Encoder {
+        assignedNode(forKey: key)
+    }
+
+    func encodeNil(forKey key: CodingKey) throws {
+        // If a value is nil, then it is not encoded
+        // This is not consistent with the documentation of `decodeNil(forKey:)`,
+        // which states that decodeNil() should fail if the key is not present.
+        // We could fix this by explicitly assigning a `nil` value:
+        // `assign(NilContainer(), forKey: key)`
+        // But this would cause other problems, either breaking the decoding of double optionals (e.g. Int??),
+        // Or by requiring an additional `nil` indicator for ALL values in keyed containers,
+        // which would make the format a lot less efficient
+    }
+
+    func encode<T>(_ value: T, forKey key: CodingKey) throws where T : Encodable {
+        let encoded = try encodeValue(value, needsLengthData: true)
+        assign(encoded, forKey: key)
+    }
+}
+
+extension KeyedEncoderStorage: EncodableContainer {
+
+    var needsNilIndicator: Bool {
+        false
+    }
+
+    var isNil: Bool {
+        false
+    }
+
+    func containedData() throws -> Data {
+        guard sortKeysDuringEncoding else {
+            return try encode(elements: encodedValues)
+        }
+        return try encode(elements: encodedValues.sorted { $0.key < $1.key })
+    }
+
+    private func encode<T>(elements: T) throws -> Data where T: Collection, T.Element == (key: HashableKey, value: EncodableContainer) {
+        try elements.mapAndJoin { key, value in
+            guard let keyData = key.key.keyData() else {
+                throw EncodingError.invalidValue(key.key.intValue!, .init(codingPath: codingPath + [key.key], debugDescription: "Invalid integer value for coding key"))
+            }
+            let data = try value.completeData()
+            return keyData + data
+        }
+    }
+}

--- a/Sources/BinaryCodable/Encoding/UnkeyedEncoderStorage.swift
+++ b/Sources/BinaryCodable/Encoding/UnkeyedEncoderStorage.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+final class UnkeyedEncoderStorage: AbstractEncodingNode {
+
+    private var encodedValues: [EncodableContainer] = []
+
+    var count: Int {
+        encodedValues.count
+    }
+
+    func encodeNil() throws {
+        encodedValues.append(NilContainer())
+    }
+
+    @discardableResult
+    func add<T>(_ value: T) -> T where T: EncodableContainer {
+        encodedValues.append(value)
+        return value
+    }
+
+    func addedNode() -> EncodingNode {
+        let node = EncodingNode(needsLengthData: true, codingPath: codingPath, userInfo: userInfo)
+        return add(node)
+    }
+
+    func encode<T>(_ value: T) throws where T : Encodable {
+        let encoded = try encodeValue(value, needsLengthData: true)
+        add(encoded)
+    }
+
+}
+
+extension UnkeyedEncoderStorage: EncodableContainer {
+
+    var needsNilIndicator: Bool {
+        false
+    }
+
+    var isNil: Bool {
+        false
+    }
+
+    func containedData() throws -> Data {
+        try encodedValues.mapAndJoin {
+            try $0.completeData()
+        }
+    }
+}

--- a/Sources/BinaryCodable/Encoding/ValueEncoder.swift
+++ b/Sources/BinaryCodable/Encoding/ValueEncoder.swift
@@ -1,41 +1,22 @@
 import Foundation
 
-final class ValueEncoder: AbstractEncodingNode, SingleValueEncodingContainer {
+struct ValueEncoder: SingleValueEncodingContainer {
 
-    private var encodedValue: EncodableContainer?
+    var codingPath: [any CodingKey] {
+        storage.codingPath
+    }
 
-    init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
-        super.init(needsLengthData: false, codingPath: codingPath, userInfo: userInfo)
+    private var storage: ValueEncoderStorage
+
+    init(storage: ValueEncoderStorage) {
+        self.storage = storage
     }
 
     func encodeNil() throws {
-        guard encodedValue == nil else {
-            throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "Single value container: Multiple calls to encodeNil() or encode<T>()"))
-        }
-        encodedValue = NilContainer()
+        try storage.encodeNil()
     }
 
     func encode<T>(_ value: T) throws where T : Encodable {
-        guard encodedValue == nil else {
-            throw EncodingError.invalidValue(value, .init(codingPath: codingPath, debugDescription: "Single value container: Multiple calls to encodeNil() or encode<T>()"))
-        }
-        self.encodedValue = try encodeValue(value, needsLengthData: false)
-    }
-}
-
-extension ValueEncoder: EncodableContainer {
-
-    var needsNilIndicator: Bool { true }
-
-    var isNil: Bool {
-        encodedValue is NilContainer
-    }
-
-    func containedData() throws -> Data {
-        guard let encodedValue else {
-            throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "No value or nil encoded in single value container"))
-        }
-        let data = try encodedValue.completeData()
-        return data
+        try storage.encode(value)
     }
 }

--- a/Sources/BinaryCodable/Encoding/ValueEncoderStorage.swift
+++ b/Sources/BinaryCodable/Encoding/ValueEncoderStorage.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/**
+ The backing storage for single value containers.
+
+ Encodes a single value.
+ It can be set multiple times, but only the last value is used.
+ */
+final class ValueEncoderStorage: AbstractEncodingNode {
+
+    private var encodedValue: EncodableContainer?
+
+    init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        super.init(needsLengthData: false, codingPath: codingPath, userInfo: userInfo)
+    }
+
+    func encodeNil() throws {
+        // Note: An already encoded value will simply be replaced
+        // This is consistent with the implementation of JSONEncoder()
+        encodedValue = NilContainer()
+    }
+
+    func encode<T>(_ value: T) throws where T : Encodable {
+        // Note: An already encoded value will simply be replaced
+        // This is consistent with the implementation of JSONEncoder()
+        self.encodedValue = try encodeValue(value, needsLengthData: false)
+    }
+}
+
+extension ValueEncoderStorage: EncodableContainer {
+
+    var needsNilIndicator: Bool { true }
+
+    var isNil: Bool {
+        encodedValue is NilContainer
+    }
+
+    func containedData() throws -> Data {
+        guard let encodedValue else {
+            // TODO: Provide value of outer encoding node in error
+            throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "No value or nil encoded in single value container"))
+        }
+        let data = try encodedValue.completeData()
+        return data
+    }
+}

--- a/Tests/BinaryCodableTests/ContainerTests.swift
+++ b/Tests/BinaryCodableTests/ContainerTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+import BinaryCodable
+
+final class ContainerTests: XCTestCase {
+
+    /**
+     Test that it's possible to create multiple single value containers on the same encoder,
+     and that only the last value is saved, regardless of which container is used.
+     */
+    func testMultipleCallsToSingleContainer() throws {
+        struct Test: Codable, Equatable {
+            let key: String
+
+            init(key: String) {
+                self.key = key
+            }
+
+            enum CodingKeys: CodingKey {
+                case key
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                var container1 = encoder.singleValueContainer()
+                var container2 = encoder.singleValueContainer()
+                try container1.encode("abc")
+                try container2.encode(key)
+            }
+
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                self.key = try container.decode(String.self)
+            }
+        }
+
+        let value = Test(key: "ABC")
+        try compare(value)
+    }
+
+    /**
+     Test that encoding fails if no calls are made to a single value container.
+     */
+    func testNoValueEncodedInSingleValueContainer() throws {
+        struct Test: Codable, Equatable {
+            let key: String
+
+            init(key: String) {
+                self.key = key
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                let _ = encoder.singleValueContainer()
+            }
+        }
+
+        let value = Test(key: "ABC")
+        do {
+            _ = try BinaryEncoder().encode(value)
+            XCTFail("Should not be able to encode type with unset single value container")
+        } catch EncodingError.invalidValue(_, let context) {
+            XCTAssertEqual(context.codingPath, [])
+            XCTAssertNil(context.underlyingError)
+        }
+    }
+
+    /**
+     Test that multiple keyed containers can be used to encode values
+     */
+    func testMultipleKeyedContainersForEncoding() throws {
+        struct Test: Codable, Equatable {
+            let a: String
+            let b: String
+
+            func encode(to encoder: any Encoder) throws {
+                var container1 = encoder.container(keyedBy: CodingKeys.self)
+                var container2 = encoder.container(keyedBy: CodingKeys.self)
+                try container1.encode(a, forKey: .a)
+                try container2.encode(b, forKey: .b)
+            }
+        }
+
+        try compare(Test(a: "a", b: "b"))
+    }
+
+    /**
+     Test that it's possible to encode values from a derived class and the super class
+     in the same keyed container.
+     */
+    func testEncodingSuperAndSubclassInSameKeyedContainer() throws {
+        class TestSuper: Codable {
+            let a: Int
+            init(a: Int) {
+                self.a = a
+            }
+        }
+
+        class TestDerived: TestSuper, Equatable {
+
+            static func == (lhs: TestDerived, rhs: TestDerived) -> Bool {
+                lhs.a == rhs.a && lhs.b == rhs.b
+            }
+
+            let b: Int
+
+            init(a: Int, b: Int) {
+                self.b = b
+                super.init(a: a)
+            }
+
+            required init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.b = try container.decode(Int.self, forKey: .b)
+                try super.init(from: decoder)
+            }
+
+            override func encode(to encoder: any Encoder) throws {
+                try super.encode(to: encoder)
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(b, forKey: .b)
+            }
+
+            enum CodingKeys: CodingKey {
+                case b
+            }
+        }
+
+        let value = TestDerived(a: 123, b: 234)
+        let data = try BinaryEncoder().encode(value)
+        print(Array(data))
+
+        try compare(value)
+    }
+
+    func testUseMultipleKeyedDecoders() throws {
+        struct Test: Codable, Equatable {
+            let a: Int
+            let b: Int
+
+            init(a: Int, b: Int) {
+                self.a = a
+                self.b = b
+            }
+
+            enum CodingKeys1: CodingKey {
+                case a
+            }
+
+            enum CodingKeys2: CodingKey {
+                case b
+            }
+
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys1.self)
+                self.a = try container.decode(Int.self, forKey: .a)
+                let container2 = try decoder.container(keyedBy: CodingKeys2.self)
+                self.b = try container2.decode(Int.self, forKey: .b)
+            }
+        }
+        try compare(Test(a: 123, b: 234))
+    }
+
+    /**
+     Test that multiple unkeyed containers on the same node can be used,
+     and that they encode values is the order of insertion independent of the container used.
+     */
+    func testUseMultipleUnkeyedEncoders() throws {
+        struct Test: Codable, Equatable {
+            let a: Int
+            let b: Int
+
+            init(a: Int, b: Int) {
+                self.a = a
+                self.b = b
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                var container1 = encoder.unkeyedContainer()
+                var container2 = encoder.unkeyedContainer()
+                try container2.encode(a)
+                try container1.encode(b)
+            }
+
+            init(from decoder: any Decoder) throws {
+                var container = try decoder.unkeyedContainer()
+                self.a = try container.decode(Int.self)
+                self.b = try container.decode(Int.self)
+            }
+        }
+        try compare(Test(a: 123, b: 234))
+    }
+}

--- a/Tests/BinaryCodableTests/GenericTestStruct.swift
+++ b/Tests/BinaryCodableTests/GenericTestStruct.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/**
+ A struct to provide custom encode and decode functions via static properties
+ for testing. Reduces the need to create full struct definitions when testing custom
+ encoding and decoding routines
+ */
+struct GenericTestStruct: Codable, Equatable {
+
+    init() {
+
+    }
+
+    init(from decoder: Decoder) throws {
+        try GenericTestStruct.decodingRoutine(decoder)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try GenericTestStruct.encodingRoutine(encoder)
+    }
+
+    private static nonisolated(unsafe) var _encodingRoutine: (Encoder) throws -> Void = { _ in }
+
+    private static nonisolated(unsafe) var _decodingRoutine: (Decoder) throws -> Void = { _ in }
+
+    private static let encodeSemaphore = DispatchSemaphore(value: 1)
+
+    static var encodingRoutine: (Encoder) throws -> Void {
+        get {
+            encodeSemaphore.wait()
+            let value = _encodingRoutine
+            encodeSemaphore.signal()
+            return value
+        }
+        set {
+            encodeSemaphore.wait()
+            _encodingRoutine = newValue
+            encodeSemaphore.signal()
+        }
+    }
+
+    private static let decodeSemaphore = DispatchSemaphore(value: 1)
+
+    static var decodingRoutine: (Decoder) throws -> Void {
+        get {
+            decodeSemaphore.wait()
+            let value = _decodingRoutine
+            decodeSemaphore.signal()
+            return value
+        }
+        set {
+            decodeSemaphore.wait()
+            _decodingRoutine = newValue
+            decodeSemaphore.signal()
+        }
+    }
+
+    static func encode(_ block: @escaping (Encoder) throws -> Void) {
+        encodingRoutine = block
+    }
+
+    static func decode(_ block: @escaping (Decoder) throws -> Void) {
+        decodingRoutine = block
+    }
+}
+

--- a/Tests/BinaryCodableTests/Helper.swift
+++ b/Tests/BinaryCodableTests/Helper.swift
@@ -2,65 +2,6 @@ import Foundation
 import XCTest
 @testable import BinaryCodable
 
-struct GenericTestStruct: Codable, Equatable {
-
-    init() {
-
-    }
-
-    init(from decoder: Decoder) throws {
-        try GenericTestStruct.decodingRoutine(decoder)
-    }
-
-    func encode(to encoder: Encoder) throws {
-        try GenericTestStruct.encodingRoutine(encoder)
-    }
-
-    private static nonisolated(unsafe) var _encodingRoutine: (Encoder) throws -> Void = { _ in }
-
-    private static nonisolated(unsafe) var _decodingRoutine: (Decoder) throws -> Void = { _ in }
-    
-    private static let encodeSemaphore = DispatchSemaphore(value: 1)
-    
-    static var encodingRoutine: (Encoder) throws -> Void {
-        get {
-            encodeSemaphore.wait()
-            let value = _encodingRoutine
-            encodeSemaphore.signal()
-            return value
-        }
-        set {
-            encodeSemaphore.wait()
-            _encodingRoutine = newValue
-            encodeSemaphore.signal()
-        }
-    }
-    
-    private static let decodeSemaphore = DispatchSemaphore(value: 1)
-    
-    static var decodingRoutine: (Decoder) throws -> Void {
-        get {
-            decodeSemaphore.wait()
-            let value = _decodingRoutine
-            decodeSemaphore.signal()
-            return value
-        }
-        set {
-            decodeSemaphore.wait()
-            _decodingRoutine = newValue
-            decodeSemaphore.signal()
-        }
-    }
-
-    static func encode(_ block: @escaping (Encoder) throws -> Void) {
-        encodingRoutine = block
-    }
-
-    static func decode(_ block: @escaping (Decoder) throws -> Void) {
-        decodingRoutine = block
-    }
-}
-
 func XCTAssertEqual(_ path: [CodingKey], _ other: [DecodingKey]) {
     let convertedPath = path.map { DecodingKey(key: $0) }
     XCTAssertEqual(convertedPath, other)

--- a/Tests/BinaryCodableTests/KeyedEncodingTests.swift
+++ b/Tests/BinaryCodableTests/KeyedEncodingTests.swift
@@ -215,4 +215,36 @@ final class KeyedEncodingTests: XCTestCase {
         }
         try compare(GenericTestStruct(), to: [])
     }
+
+    /**
+     Check that assigning to the same key twice saves the second value.
+     Also check that it's possible to read the same key multiple times.
+     */
+    func testAssigningAndReadKeyTwice() throws {
+        struct TestStruct: Codable, Equatable {
+            let key: String
+
+            init(key: String) {
+                self.key = key
+            }
+
+            enum CodingKeys: CodingKey {
+                case key
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode("ABC", forKey: .key)
+                try container.encode(key, forKey: .key)
+            }
+
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let _ = try container.decode(String.self, forKey: .key)
+                self.key = try container.decode(String.self, forKey: .key)
+            }
+        }
+
+        try compare(TestStruct(key: "abc"))
+    }
 }

--- a/Tests/BinaryCodableTests/PropertyWrapperCodingTests.swift
+++ b/Tests/BinaryCodableTests/PropertyWrapperCodingTests.swift
@@ -72,10 +72,10 @@ final class PropertyWrapperCodingTests: XCTestCase {
 
         // If the suffix differs, this error is specific to the individual test case,
         // so report it on the call-side
-        XCTAssertEqual(Array(data.suffix(from: bytePrefix.count)), byteSuffix, file: file, line: line)
+        XCTAssertEqual(Array(data.suffix(from: bytePrefix.count)), byteSuffix, file: (file), line: line)
 
         let decodedWrapper: KeyedWrapper<T> = try BinaryDecoder.decode(from: data)
-        XCTAssertEqual(decodedWrapper, wrapper, file: file, line: line)
+        XCTAssertEqual(decodedWrapper, wrapper, file: (file), line: line)
     }
 
     func testOptionalWrappedStringSome() throws {

--- a/Tests/BinaryCodableTests/SuperEncodingTests.swift
+++ b/Tests/BinaryCodableTests/SuperEncodingTests.swift
@@ -118,4 +118,44 @@ final class SuperEncodingTests: XCTestCase {
         ]
         try compare(value, toOneOf: [part1 + part2, part2 + part1])
     }
+
+    func testInheritance() throws {
+        class ParentClass: Codable {
+            var text: String = ""
+        }
+
+        final class ChildClass: ParentClass, Equatable {
+            static func == (lhs: ChildClass, rhs: ChildClass) -> Bool {
+                lhs.text == rhs.text && lhs.image == rhs.image
+            }
+
+            var image: Data?
+
+            enum CodingKeys: String, CodingKey {
+                case image
+            }
+
+            override init() {
+                self.image = nil
+                super.init()
+            }
+
+            required init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.image = try container.decodeIfPresent(Data.self, forKey: .image)
+                try super.init(from: decoder)
+            }
+
+            override func encode(to encoder: any Encoder) throws {
+                try super.encode(to: encoder)
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(image, forKey: .image)
+            }
+        }
+
+        let child = ChildClass()
+        child.image = Data(repeating: 42, count: 42)
+
+        try compare(child)
+    }
 }


### PR DESCRIPTION
Fixes issues with custom encoding implementations, especially in relation to classes with inheritance.

Some situations previously prohibited are now allowed, such as performing multiple calls to containers on an `Encoder`, as long as the same type of container is requested.
The underlying storage is shared between all containers, to give more flexibility for custom encodings and to align the behaviour more closely with `JSONEncoder`. 