### PR TITLE
feat: Expose internal coders with SPI attribute

### DIFF
--- a/Sources/BinaryCodable/Common/AbstractNode.swift
+++ b/Sources/BinaryCodable/Common/AbstractNode.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Contextual information set by the user for encoding or decoding
-typealias UserInfo = [CodingUserInfoKey : Any]
+@_spi(internals) public
+typealias UserInfo = [CodingUserInfoKey: Any]
 
 /**
  A node in the encoding and decoding hierarchy.
@@ -11,11 +12,13 @@ typealias UserInfo = [CodingUserInfoKey : Any]
 
  Child classes: `AbstractEncodingNode` and `AbstractDecodingNode`
  */
+@_spi(internals) public
 class AbstractNode {
 
     /**
      The path of coding keys taken to get to this point in encoding or decoding.
      */
+    @_spi(internals) public
     let codingPath: [CodingKey]
 
     /**
@@ -23,6 +26,7 @@ class AbstractNode {
 
      Contains also keys for any custom options set for the encoder and decoder. See `CodingOption`.
      */
+    @_spi(internals) public
     let userInfo: UserInfo
 
     /**

--- a/Sources/BinaryCodable/Common/AbstractNode.swift
+++ b/Sources/BinaryCodable/Common/AbstractNode.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Contextual information set by the user for encoding or decoding
-@_spi(internals) public
+@_spi(Internals) public
 typealias UserInfo = [CodingUserInfoKey: Any]
 
 /**
@@ -12,13 +12,13 @@ typealias UserInfo = [CodingUserInfoKey: Any]
 
  Child classes: `AbstractEncodingNode` and `AbstractDecodingNode`
  */
-@_spi(internals) public
+@_spi(Internals) public
 class AbstractNode {
 
     /**
      The path of coding keys taken to get to this point in encoding or decoding.
      */
-    @_spi(internals) public
+    @_spi(Internals) public
     let codingPath: [CodingKey]
 
     /**
@@ -26,7 +26,7 @@ class AbstractNode {
 
      Contains also keys for any custom options set for the encoder and decoder. See `CodingOption`.
      */
-    @_spi(internals) public
+    @_spi(Internals) public
     let userInfo: UserInfo
 
     /**

--- a/Sources/BinaryCodable/Decoding/AbstractDecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/AbstractDecodingNode.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A class to provide decoding functions to all decoding containers.
  */
-@_spi(internals) public
+@_spi(Internals) public
 class AbstractDecodingNode: AbstractNode {
 
     let parentDecodedNil: Bool

--- a/Sources/BinaryCodable/Decoding/AbstractDecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/AbstractDecodingNode.swift
@@ -3,6 +3,7 @@ import Foundation
 /**
  A class to provide decoding functions to all decoding containers.
  */
+@_spi(internals) public
 class AbstractDecodingNode: AbstractNode {
 
     let parentDecodedNil: Bool

--- a/Sources/BinaryCodable/Decoding/DecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/DecodingNode.swift
@@ -1,14 +1,20 @@
 import Foundation
 
-/**
- A class acting as a decoder, to provide different containers for decoding.
- */
-@_spi(internals) public
+/// A class acting as a decoder, to provide different containers for decoding.
+///
+/// Exposed via SPI to allow consumer modules to build proxy-style wrapper decoders
+/// without making it part of the public API.
+///
+/// To import `DecodingNode`, add the `@_spi(Internals)` attribute to your import statement:
+/// ```swift
+/// @_spi(Internals) import BinaryCodable
+/// ```
+@_spi(Internals) public
 final class DecodingNode: AbstractDecodingNode, Decoder {
 
     private let data: Data?
 
-    @_spi(internals) public
+    @_spi(Internals) public
     init(data: Data?, parentDecodedNil: Bool, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) throws {
         self.data = data
         super.init(parentDecodedNil: parentDecodedNil, codingPath: codingPath, userInfo: userInfo)
@@ -57,19 +63,19 @@ final class DecodingNode: AbstractDecodingNode, Decoder {
         }
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
         let data = try getNonNilElement()
         return KeyedDecodingContainer(try KeyedDecoder(data: data, codingPath: codingPath, userInfo: userInfo))
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func unkeyedContainer() throws -> UnkeyedDecodingContainer {
         let data = try getNonNilElement()
         return try UnkeyedDecoder(data: data, codingPath: codingPath, userInfo: userInfo)
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func singleValueContainer() throws -> SingleValueDecodingContainer {
         let data = try getPotentialNilElement()
         return ValueDecoder(data: data, codingPath: codingPath, userInfo: userInfo)

--- a/Sources/BinaryCodable/Decoding/DecodingNode.swift
+++ b/Sources/BinaryCodable/Decoding/DecodingNode.swift
@@ -3,10 +3,12 @@ import Foundation
 /**
  A class acting as a decoder, to provide different containers for decoding.
  */
+@_spi(internals) public
 final class DecodingNode: AbstractDecodingNode, Decoder {
 
     private let data: Data?
 
+    @_spi(internals) public
     init(data: Data?, parentDecodedNil: Bool, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) throws {
         self.data = data
         super.init(parentDecodedNil: parentDecodedNil, codingPath: codingPath, userInfo: userInfo)
@@ -55,16 +57,19 @@ final class DecodingNode: AbstractDecodingNode, Decoder {
         }
     }
 
+    @_spi(internals) public
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
         let data = try getNonNilElement()
         return KeyedDecodingContainer(try KeyedDecoder(data: data, codingPath: codingPath, userInfo: userInfo))
     }
 
+    @_spi(internals) public
     func unkeyedContainer() throws -> UnkeyedDecodingContainer {
         let data = try getNonNilElement()
         return try UnkeyedDecoder(data: data, codingPath: codingPath, userInfo: userInfo)
     }
 
+    @_spi(internals) public
     func singleValueContainer() throws -> SingleValueDecodingContainer {
         let data = try getPotentialNilElement()
         return ValueDecoder(data: data, codingPath: codingPath, userInfo: userInfo)

--- a/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
@@ -3,14 +3,17 @@ import Foundation
 /**
  A class that provides encoding functions for all encoding containers.
  */
+@_spi(internals) public
 class AbstractEncodingNode: AbstractNode {
 
+    @_spi(internals) public
     let needsLengthData: Bool
 
     /**
     - Parameter codingPath: The path to get to this point in encoding or decoding
     - Parameter userInfo: Contextual information set by the user
     */
+    @_spi(internals) public
     init(needsLengthData: Bool, codingPath: [CodingKey], userInfo: UserInfo) {
         self.needsLengthData = needsLengthData
         super.init(codingPath: codingPath, userInfo: userInfo)

--- a/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/AbstractEncodingNode.swift
@@ -3,17 +3,17 @@ import Foundation
 /**
  A class that provides encoding functions for all encoding containers.
  */
-@_spi(internals) public
+@_spi(Internals) public
 class AbstractEncodingNode: AbstractNode {
 
-    @_spi(internals) public
+    @_spi(Internals) public
     let needsLengthData: Bool
 
     /**
     - Parameter codingPath: The path to get to this point in encoding or decoding
     - Parameter userInfo: Contextual information set by the user
     */
-    @_spi(internals) public
+    @_spi(Internals) public
     init(needsLengthData: Bool, codingPath: [CodingKey], userInfo: UserInfo) {
         self.needsLengthData = needsLengthData
         super.init(codingPath: codingPath, userInfo: userInfo)

--- a/Sources/BinaryCodable/Encoding/EncodableContainer.swift
+++ b/Sources/BinaryCodable/Encoding/EncodableContainer.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A protocol adopted by primitive types for encoding.
  */
-@_spi(internals) public
+@_spi(Internals) public
 protocol EncodableContainer {
 
     /// Indicate if the container needs to have a length prepended
@@ -29,7 +29,7 @@ extension EncodableContainer {
     /**
      The full data encoded in the container, including nil indicator and length, if needed
      */
-    @_spi(internals) public
+    @_spi(Internals) public
     func completeData() throws -> Data {
         guard !isNil else {
             // A nil value always means:

--- a/Sources/BinaryCodable/Encoding/EncodableContainer.swift
+++ b/Sources/BinaryCodable/Encoding/EncodableContainer.swift
@@ -3,6 +3,7 @@ import Foundation
 /**
  A protocol adopted by primitive types for encoding.
  */
+@_spi(internals) public
 protocol EncodableContainer {
 
     /// Indicate if the container needs to have a length prepended
@@ -28,6 +29,7 @@ extension EncodableContainer {
     /**
      The full data encoded in the container, including nil indicator and length, if needed
      */
+    @_spi(internals) public
     func completeData() throws -> Data {
         guard !isNil else {
             // A nil value always means:

--- a/Sources/BinaryCodable/Encoding/EncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/EncodingNode.swift
@@ -1,11 +1,18 @@
 import Foundation
 
-@_spi(internals) public
+/// Exposed via SPI to allow consumer modules to build proxy-style wrapper encoders
+/// without making it part of the public API.
+///
+/// To import `EncodingNode`, add the `@_spi(Internals)` attribute to your import statement:
+/// ```swift
+/// @_spi(Internals) import BinaryCodable
+/// ```
+@_spi(Internals) public
 final class EncodingNode: AbstractEncodingNode, Encoder {
 
     private var encodedValue: EncodableContainer? = nil
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
         guard let encodedValue else {
             let storage = KeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
@@ -18,7 +25,7 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
         return KeyedEncodingContainer(KeyedEncoder(storage: storage))
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func unkeyedContainer() -> UnkeyedEncodingContainer {
         guard let encodedValue else {
             let storage = UnkeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
@@ -31,7 +38,7 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
         return UnkeyedEncoder(storage: storage)
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func singleValueContainer() -> SingleValueEncodingContainer {
         guard let encodedValue else {
             // No previous container generated, create the storage
@@ -52,19 +59,19 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
 
 extension EncodingNode: EncodableContainer {
 
-    @_spi(internals) public
+    @_spi(Internals) public
     var needsNilIndicator: Bool {
         // If no value is encoded, then it doesn't matter what is returned, `encodedData()` will throw an error
         encodedValue?.needsNilIndicator ?? false
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     var isNil: Bool {
         // Returning false for missing encodedValue forces an error on `encodedData()`
         encodedValue?.isNil ?? false
     }
 
-    @_spi(internals) public
+    @_spi(Internals) public
     func containedData() throws -> Data {
         guard let encodedValue else {
             throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "No calls to container(keyedBy:), unkeyedContainer(), or singleValueContainer()"))

--- a/Sources/BinaryCodable/Encoding/EncodingNode.swift
+++ b/Sources/BinaryCodable/Encoding/EncodingNode.swift
@@ -1,9 +1,11 @@
 import Foundation
 
+@_spi(internals) public
 final class EncodingNode: AbstractEncodingNode, Encoder {
 
     private var encodedValue: EncodableContainer? = nil
 
+    @_spi(internals) public
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
         guard let encodedValue else {
             let storage = KeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
@@ -16,6 +18,7 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
         return KeyedEncodingContainer(KeyedEncoder(storage: storage))
     }
 
+    @_spi(internals) public
     func unkeyedContainer() -> UnkeyedEncodingContainer {
         guard let encodedValue else {
             let storage = UnkeyedEncoderStorage(needsLengthData: needsLengthData, codingPath: codingPath, userInfo: userInfo)
@@ -28,6 +31,7 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
         return UnkeyedEncoder(storage: storage)
     }
 
+    @_spi(internals) public
     func singleValueContainer() -> SingleValueEncodingContainer {
         guard let encodedValue else {
             // No previous container generated, create the storage
@@ -48,16 +52,19 @@ final class EncodingNode: AbstractEncodingNode, Encoder {
 
 extension EncodingNode: EncodableContainer {
 
+    @_spi(internals) public
     var needsNilIndicator: Bool {
         // If no value is encoded, then it doesn't matter what is returned, `encodedData()` will throw an error
         encodedValue?.needsNilIndicator ?? false
     }
 
+    @_spi(internals) public
     var isNil: Bool {
         // Returning false for missing encodedValue forces an error on `encodedData()`
         encodedValue?.isNil ?? false
     }
 
+    @_spi(internals) public
     func containedData() throws -> Data {
         guard let encodedValue else {
             throw EncodingError.invalidValue(0, .init(codingPath: codingPath, debugDescription: "No calls to container(keyedBy:), unkeyedContainer(), or singleValueContainer()"))

--- a/Tests/BinaryCodableTests/SPIImportTests.swift
+++ b/Tests/BinaryCodableTests/SPIImportTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import Foundation
+@_spi(Internals) import BinaryCodable
+
+final class SPIImportTests: XCTestCase {
+
+    // MARK: - EncodingNode Tests
+
+    func testEncodingNodeImport() {
+        // Test will fail to compile if EncodingNode is not accessible via SPI
+        let _ = EncodingNode(needsLengthData: false, codingPath: [], userInfo: [:])
+    }
+
+    func testEncodingNodeProperties() {
+        let encoder = EncodingNode(needsLengthData: true, codingPath: [], userInfo: [:])
+        let _ = encoder.needsLengthData
+        let _ = encoder.codingPath
+        let _ = encoder.userInfo
+    }
+
+    func testEncodingNodeContainerMethods() {
+        struct TestKey: CodingKey {
+            var stringValue: String
+            var intValue: Int?
+            init(stringValue: String) { self.stringValue = stringValue }
+            init(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
+        }
+        
+        // Each container method must be called on a separate encoder instance
+        let encoder1 = EncodingNode(needsLengthData: false, codingPath: [], userInfo: [:])
+        let _ = encoder1.container(keyedBy: TestKey.self)
+        
+        let encoder2 = EncodingNode(needsLengthData: false, codingPath: [], userInfo: [:])
+        let _ = encoder2.unkeyedContainer()
+        
+        let encoder3 = EncodingNode(needsLengthData: false, codingPath: [], userInfo: [:])
+        let _ = encoder3.singleValueContainer()
+    }
+
+    func testEncodingNodeEncodableContainerProperties() {
+        let encoder = EncodingNode(needsLengthData: false, codingPath: [], userInfo: [:])
+        let _ = encoder.needsNilIndicator
+        let _ = encoder.isNil
+    }
+
+    // MARK: - DecodingNode Tests
+
+    func testDecodingNodeImport() throws {
+        // Test will fail to compile if DecodingNode is not accessible via SPI
+        let _ = try DecodingNode(data: Data([1, 2, 3]), parentDecodedNil: false, codingPath: [], userInfo: [:])
+    }
+
+    func testDecodingNodeProperties() throws {
+        struct TestKey: CodingKey {
+            var stringValue: String
+            var intValue: Int?
+            init(stringValue: String) { self.stringValue = stringValue }
+            init(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
+        }
+        
+        let decoder = try DecodingNode(data: Data([1, 2, 3]), parentDecodedNil: false, codingPath: [TestKey(stringValue: "test")], userInfo: [:])
+        let _ = decoder.codingPath
+        let _ = decoder.userInfo
+    }
+    // MARK: - AbstractNode Tests
+
+    func testAbstractNodeProperties() {
+        struct TestKey: CodingKey {
+            var stringValue: String
+            var intValue: Int?
+            init(stringValue: String) { self.stringValue = stringValue }
+            init(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
+        }
+        
+        let encoder = EncodingNode(needsLengthData: false, codingPath: [TestKey(stringValue: "test")], userInfo: [:])
+        let _ = encoder.codingPath
+        let _ = encoder.userInfo
+    }
+
+    // MARK: - AbstractEncodingNode Tests
+
+    func testAbstractEncodingNodeProperties() {
+        let encoder = EncodingNode(needsLengthData: true, codingPath: [], userInfo: [:])
+        let _ = encoder.needsLengthData
+    }
+}


### PR DESCRIPTION
# Expose Internal Coders with SPI Attribute

Marks internal encoding/decoding types with `@_spi(internals) public` so consumer modules can access them without making them part of the public API. Useful for test targets and custom encoder implementations.

## Changes

- Added `@_spi(internals)` attribute to:
  - `EncodingNode` class and its container methods
  - `DecodingNode` class
  - `AbstractEncodingNode` class
  - `AbstractDecodingNode` class
  - `AbstractNode` class

## Motivation

This enables proxy-style wrapper encoders/decoders. You can wrap BinaryCodable's internal nodes and intercept encoding calls to add custom behavior (like handling XPC objects or custom formats) while still using BinaryCodable for the actual encoding work.

### Example: XPC Encoder

XPC can't serialize everything as binary data. Things like file descriptors and Mach ports need to be sent as native `xpc_object_t` types because they require internal right transfer. So we need a hybrid approach: binary-encode regular data, but handle XPC objects separately.

Here's how we use the SPI to build a custom XPC encoder:

```swift
import Foundation
@_spi(internals) import BinaryCodable

struct XPCEncoder: Encoder {
    
    var userInfo: [CodingUserInfoKey: Any] = [:]
    let wrappedEncoder: EncodingNode
    let xpcDict: xpc_object_t
    let context = XPCCodingContext()
    
    init(xpcDict: xpc_object_t) {
        self.xpcDict = xpcDict
        self.wrappedEncoder = EncodingNode(needsLengthData: false, codingPath: [], userInfo: userInfo)
    }

    var codingPath: [CodingKey] { wrappedEncoder.codingPath }
    
    func encode<T: Codable>(_ value: T) throws {
        try value.encode(to: self)
        let encodedPayload = try wrappedEncoder.completeData()
        encodedPayload.withUnsafeBytes { bytes in
            xpc_dictionary_set_data(xpcDict, XPCDictPacketKey.packetPayload.rawValue, bytes.baseAddress!, bytes.count)
        }
        if let attachmentsXPCDictionary = context.attachmentsXPCDictionary {
            xpc_dictionary_set_value(xpcDict, XPCDictPacketKey.attachedXPCObjects.rawValue, attachmentsXPCDictionary)
        }
    }
    
    // MARK: - Proxy
    func unkeyedContainer() -> UnkeyedEncodingContainer { wrappedEncoder.unkeyedContainer() }
    func singleValueContainer() -> SingleValueEncodingContainer { wrappedEncoder.singleValueContainer() }
    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
        let container = XPCEncoderKeyedEncodingContainer(context: context, wrapped: wrappedEncoder.container(keyedBy: type))
        return KeyedEncodingContainer(container)
    }
}
```

The wrapper intercepts encoding calls at the keyed container level. When it sees an `XPCCodable` object, it routes it to a separate XPC attachments dictionary. Everything else gets passed through to the wrapped `EncodingNode` for normal binary encoding. This lets us mix binary-encoded payloads with XPC objects in the same message.

## Benefits

- Enables advanced use cases without polluting the public API
- Supports building domain-specific encoders/decoders on top of BinaryCodable

